### PR TITLE
Set file permissions to 0600 for longhorn config

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,6 +20,7 @@
       ansible.builtin.template:
         src: "longhorn-config.j2"
         dest: "{{ longhorn_config_path }}"
+        mode: '0600'
 
     - name: install Longhorn
       kubernetes.core.helm:


### PR DESCRIPTION
# Pull Request Description
Longhorn config should not be readable by anyone other than the designated Ansible user.
Set file permissions to 0600 for Longhorn config.

## Change type

- [x] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
Tested on Ubuntu 20.04 and 22.04 using Vagrant.